### PR TITLE
Replace echo to .env with custom edit-env CLI command

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,7 @@
 version=$(jq -r '.version' < package.json)
 
 git pull
-echo "LAST_UPDATED=$(date -Iseconds)" >> .env
+npx alex-c-line edit-env LAST_UPDATED $(date -Iseconds)
 docker build -t alex-g-bot-2:$version .
 
 docker stop alex-g-bot-2


### PR DESCRIPTION
This should get rid of the duplicated key in .env that you get from echo.