### PR TITLE
Use eslint --fix --quiet in format script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "npx tsx src/index.ts",
     "dev": "nodemon src/index.ts",
-    "format": "prettier --write --parser typescript 'src/**/*.ts' 'prisma/**/*.ts' && ESLINT_MODE=fix eslint --fix 'src/**/*.ts' 'prisma/**/*.ts'",
+    "format": "prettier --write --parser typescript 'src/**/*.ts' 'prisma/**/*.ts' && ESLINT_MODE=fix eslint --fix --quiet 'src/**/*.ts' 'prisma/**/*.ts'",
     "lint": "ESLINT_MODE=lint eslint 'src/**/*.ts' 'prisma/**/*.ts' && prettier --check --parser typescript 'src/**/*.ts' 'prisma/**/*.ts'",
     "prepare": "husky",
     "update-dependencies": "npx npm-check-updates -u && npm install",


### PR DESCRIPTION
This ensures that we don't get ESLint errors when running the format script.