### PR TITLE
Do not run update script on repository forks

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   update-dependencies:
+    if: ${{ github.repository == 'AlexMan123456/alex-g-bot-2' }}
     runs-on: ubuntu-latest
     env:
       HUSKY: 0


### PR DESCRIPTION
The update script should only ever run on the main version of the repository, and never on forks. I think forks should be able to synchronise their versions with my repository when I make updates anyway, so there's no real reason they should be able to run this script.