### PR TITLE
Make overrides more specific

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,8 @@
   "packageManager": "pnpm@10.24.0+sha512.01ff8ae71b4419903b65c60fb2dc9d34cf8bb6e06d03bde112ef38f7a34d6904c424ba66bea5cdcf12890230bf39f9580473140ed9c946fef328b6e5238a345a",
   "pnpm": {
     "overrides": {
-      "prisma": "<=6.19.0",
-      "@prisma/client": "<=6.19.0"
+      "prisma": "^6.19.0",
+      "@prisma/client": "^6.19.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  prisma: <=6.19.0
-  '@prisma/client': <=6.19.0
+  prisma: ^6.19.0
+  '@prisma/client': ^6.19.0
 
 importers:
 
@@ -16,7 +16,7 @@ importers:
         specifier: ^2.19.0
         version: 2.21.0
       '@prisma/client':
-        specifier: <=6.19.0
+        specifier: ^6.19.0
         version: 6.19.0(prisma@6.19.0(typescript@5.9.3))(typescript@5.9.3)
       '@sapphire/framework':
         specifier: ^5.4.0
@@ -62,7 +62,7 @@ importers:
         specifier: ^3.6.2
         version: 3.7.3
       prisma:
-        specifier: <=6.19.0
+        specifier: ^6.19.0
         version: 6.19.0(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
@@ -450,7 +450,7 @@ packages:
     resolution: {integrity: sha512-QXFT+N/bva/QI2qoXmjBzL7D6aliPffIwP+81AdTGq0FXDoLxLkWivGMawG8iM5B9BKfxLIXxfWWAF6wbuJU6g==}
     engines: {node: '>=18.18'}
     peerDependencies:
-      prisma: <=6.19.0
+      prisma: ^6.19.0
       typescript: '>=5.1.0'
     peerDependenciesMeta:
       prisma:


### PR DESCRIPTION
The lockfile always resolves to something like ^6.19.0, even when an override is specified. It resolves to whatever the dependencies field resolves to after running pnpm update or pnpm install, so it's best to ensure that the override also matches what is in the dependencies field, either specifying an exact version or one starting with ^, so that the --frozen-lockfile in actions works after updating.