### PR TITLE
Copy the correct lockfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM node:24.5.0
 
 WORKDIR /opt/bot
 
-# Copy package.json and package-lock.json
+# Copy package.json and pnpm-lock.yaml
 COPY package.json .
-COPY package-lock.json .
+COPY pnpm-lock.yaml .
 
 RUN ["pnpm", "install"]
 


### PR DESCRIPTION
Now that we're on PNPM, the lockfile is now pnpm-lock.yaml, not package-lock.json.