### PR TITLE
Add a MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License Copyright (c) 2025 AlexMan123456
+
+Permission is hereby granted, free
+of charge, to any person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice
+(including the next paragraph) shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "alex-g-bot-2",
   "version": "1.13.1",
   "description": "Discord moderation bot created in TypeScript",
-  "license": "ISC",
+  "license": "MIT",
   "author": "alextheman",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
This provides an extra sense of security, explicitly allowing people to commercially use the package, modify it, redistribute it, and use it in private projects. This feels like the standard for most open-source libraries, which is what this is intended to be.

# Documentation Change

This is a change to the documentation of `AlexGBot 2`. It changes the way that information about the bot is presented to users.

Please see the commits tab of this pull request for the description of changes.
