### PR TITLE
Add step to use Node at v22.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY package.json .
 COPY pnpm-lock.yaml .
 
 RUN ["pnpm", "install"]
+RUN ["nvm", "install", "22.10.0"]
 
 COPY tsconfig.json .
 COPY .env .


### PR DESCRIPTION
Prisma was failing because the script uses an unsupported Node version.

# Tooling Change

This is a change to the tooling of `AlexGBot 2`. It changes the internal workings of the bot that should have no noticeable effect on users.

Please see the commits tab of this pull request for the description of changes.
